### PR TITLE
Make sure to log error message + traceback (GSI-1754)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--check]
         pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,11 +1,11 @@
 [project]
 name = "dlqs"
-version = "2.0.2"
+version = "2.0.3"
 description = "DLQ Service - a service to manage the dead letter queue for Kafka events"
 dependencies = [
     "typer >= 0.15",
     "ghga-service-commons[api] >= 4.1",
-    "hexkit[akafka,mongodb] >= 5.3",
+    "hexkit[akafka,mongodb] >= 5.4.1",
 ]
 
 [project.urls]

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/dlq-service):
 ```bash
-docker pull ghga/dlq-service:2.0.2
+docker pull ghga/dlq-service:2.0.3
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/dlq-service:2.0.2 .
+docker build -t ghga/dlq-service:2.0.3 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -40,7 +40,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/dlq-service:2.0.2 --help
+docker run -p 8080:8080 ghga/dlq-service:2.0.3 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -372,9 +372,9 @@ h11==0.16.0 \
     # via
     #   httpcore
     #   uvicorn
-hexkit==5.3.0 \
-    --hash=sha256:1a1ba924e0754b9b100fe1161105483e489344a0cf5e8ffc34ccd48737b44db3 \
-    --hash=sha256:ca36fcb12834c5b485edb068e3f654f1bc61ad35b5a7bb01b0da367e7ae5afea
+hexkit==5.4.1 \
+    --hash=sha256:6879fd265e891cd5f3bfd1d86e3f75f15e4ec9b6e85d4cd121dc73d9bd84dddd \
+    --hash=sha256:dda609b31300cd2aedaf873d456c2159c6489ded8f7ba74b6e6cc07f9a1b8e33
     # via
     #   dlqs (pyproject.toml)
     #   ghga-service-commons

--- a/lock/requirements.txt
+++ b/lock/requirements.txt
@@ -206,9 +206,9 @@ h11==0.16.0 \
     #   -c lock/requirements-dev.txt
     #   httpcore
     #   uvicorn
-hexkit==5.3.0 \
-    --hash=sha256:1a1ba924e0754b9b100fe1161105483e489344a0cf5e8ffc34ccd48737b44db3 \
-    --hash=sha256:ca36fcb12834c5b485edb068e3f654f1bc61ad35b5a7bb01b0da367e7ae5afea
+hexkit==5.4.1 \
+    --hash=sha256:6879fd265e891cd5f3bfd1d86e3f75f15e4ec9b6e85d4cd121dc73d9bd84dddd \
+    --hash=sha256:dda609b31300cd2aedaf873d456c2159c6489ded8f7ba74b6e6cc07f9a1b8e33
     # via
     #   -c lock/requirements-dev.txt
     #   dlqs (pyproject.toml)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -320,7 +320,7 @@ components:
 info:
   description: A service to manage the dead letter queue for Kafka events
   title: DLQ Service
-  version: 2.0.2
+  version: 2.0.3
 openapi: 3.1.0
 paths:
   /health:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,12 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "dlqs"
-version = "2.0.2"
+version = "2.0.3"
 description = "DLQ Service - a service to manage the dead letter queue for Kafka events"
 dependencies = [
     "typer >= 0.15",
     "ghga-service-commons[api] >= 4.1",
-    "hexkit[akafka,mongodb] >= 5.3",
+    "hexkit[akafka,mongodb] >= 5.4.1",
 ]
 
 [project.license]

--- a/src/dlqs/main.py
+++ b/src/dlqs/main.py
@@ -36,7 +36,7 @@ async def run_rest_app():
     config = Config()  # type: ignore [call-arg]
     configure_logging(config=config)
 
-    if config.kafka_max_message_size < 16000000:
+    if config.kafka_max_message_size < 16_000_000:
         log.warning(
             "Kafka max message size is set to less than 16 MB. "
             "This may lead to issues with large DLQ events.",

--- a/src/dlqs/main.py
+++ b/src/dlqs/main.py
@@ -20,17 +20,28 @@ Additional endpoints might be structured in dedicated modules
 (each of them having a sub-router).
 """
 
+import logging
+
 from ghga_service_commons.api import run_server
 from hexkit.log import configure_logging
 
 from dlqs.config import Config
 from dlqs.inject import prepare_dlq_subscriber, prepare_rest_app
 
+log = logging.getLogger(__name__)
+
 
 async def run_rest_app():
     """Run the HTTP REST API."""
     config = Config()  # type: ignore [call-arg]
     configure_logging(config=config)
+
+    if config.kafka_max_message_size < 16000000:
+        log.warning(
+            "Kafka max message size is set to less than 16 MB. "
+            "This may lead to issues with large DLQ events.",
+            extra={"config.kafka_max_message_size": config.kafka_max_message_size},
+        )
 
     async with prepare_rest_app(config=config) as app:
         await run_server(app=app, config=config)

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -28,6 +28,7 @@ TEST_CONFIG_YAML = BASE_DIR / "test_config.yaml"
 def get_config(
     sources: list[BaseSettings] | None = None,
     default_config_yaml: Path = TEST_CONFIG_YAML,
+    **kwargs,
 ) -> Config:
     """Merges parameters from the default TEST_CONFIG_YAML with params inferred
     from testcontainers.
@@ -37,6 +38,7 @@ def get_config(
     if sources is not None:
         for source in sources:
             sources_dict.update(**source.model_dump())
+    sources_dict.update(**kwargs)
 
     return Config(config_yaml=default_config_yaml, **sources_dict)  # type: ignore
 

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -88,7 +88,7 @@ async def test_msg_too_big_to_publish(
         AsyncTestClient(app=app) as client,
     ):
         # clear stderr/out buffers
-        out, err = capsys.readouterr()
+        _, _ = capsys.readouterr()
         response = await client.post(
             "/test-service/test-topic",
             json={"dlq_id": str(test_event.dlq_id)},

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -16,10 +16,19 @@
 """Integration tests that focus on the REST API"""
 
 from json import loads
+from uuid import uuid4
 
 import pytest
+from ghga_service_commons.api.testing import AsyncTestClient
+from hexkit.log import configure_logging
+from hexkit.providers.akafka.testutils import KafkaFixture
+from hexkit.providers.mongodb.provider import dto_to_document
+from hexkit.providers.mongodb.testutils import MongoDbFixture
 
+from dlqs.inject import prepare_rest_app
+from dlqs.models import DLQInfo, StoredDLQEvent
 from tests.fixtures import utils
+from tests.fixtures.config import get_config
 from tests.fixtures.joint import JointFixture
 
 pytestmark = pytest.mark.asyncio
@@ -36,3 +45,63 @@ async def test_get_event_success(joint_fixture: JointFixture, prepopped_events):
     )
     assert response.status_code == 200
     assert response.json() == expected
+
+
+async def test_msg_too_big_to_publish(
+    kafka: KafkaFixture, mongodb: MongoDbFixture, capsys
+):
+    """Test that a message that is too big to publish raises an error.
+
+    The error should be logged along with the request parameters.
+    """
+    kafka_size_limit = 10000
+    config = get_config(
+        sources=[kafka.config, mongodb.config], kafka_max_message_size=kafka_size_limit
+    )
+    configure_logging(config=config)
+
+    # Make test event that exceeds the Kafka size limit
+    test_event = StoredDLQEvent(
+        dlq_id=uuid4(),
+        headers={"correlation_id": str(uuid4())},
+        topic="test-topic",
+        type_="test-type",
+        key="test-key",
+        payload={"field": "x" * (kafka_size_limit * 2)},  # 2 times the max size
+        dlq_info=DLQInfo(
+            service="test-service",
+            partition=0,
+            offset=0,
+            exc_class="TestException",
+            exc_msg="Test message",
+        ),
+    )
+
+    # Insert test data
+    db_name = config.db_name
+    db = mongodb.client[db_name]
+    test_json = dto_to_document(test_event, id_field="dlq_id")
+    db["dlqEvents"].insert_one(test_json)
+
+    async with (
+        prepare_rest_app(config=config) as app,
+        AsyncTestClient(app=app) as client,
+    ):
+        # clear stderr/out buffers
+        out, err = capsys.readouterr()
+        response = await client.post(
+            "/test-service/test-topic",
+            json={"dlq_id": str(test_event.dlq_id)},
+            headers=utils.VALID_AUTH_HEADER,
+        )
+        assert response.status_code == 500
+
+        out, err = capsys.readouterr()
+        printed_log = out + err
+
+        assert '"type": "MessageSizeTooLargeError"' in printed_log
+        assert (
+            '"request_parameters": {"service": "test-service", "topic":'
+            + f' "test-topic", "dlq_id": "{test_event.dlq_id!r}"'
+            + "}"
+        ) in printed_log


### PR DESCRIPTION
We recently had trouble diagnosing a DLQ error that was exacerbated by the lack of logs surrounding the error. This PR adds a log statement to the catch-all error handling branch.